### PR TITLE
Add py_modules argument to setup()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ README = open(os.path.join(here, 'README.rst')).read()
 setup(
     name='scrapy-multifeedexporter',
     version=version,
+    py_modules=['multifeedexporter'],
     license=open(os.path.join(here,'LICENSE')).readline().strip(),
     description='Export scraped items of different types to multiple feeds.',
     long_description=README,


### PR DESCRIPTION
The `scrapy-multifeedexporter` module isn't packaged for distribution correctly and it can't be used on, for example, [Scrapinghub](http://scrapinghub.com/).

Because it's a single file — a module not a package — it needs an extra line in `setup.py` for Setuptools to recognise the library for what it is. For more information see "[Setuptools and the single file](http://www.agapow.net/programming/python/setuptools-and-the-single-file/)", the [Distutils documentation on listing individual modules](https://docs.python.org/2/distutils/setupscript.html#listing-individual-modules), and [Xk0nSid's answer](http://stackoverflow.com/a/33432607) to the question "How can a Python module single file be installed using pip and PyPI?" on Stack Overflow.
